### PR TITLE
시장 점유율 데이터 없는 경우 매출 비중 추이만 나오도록 수정

### DIFF
--- a/src/components/MainPage/CompanyInfoPage/CompanyInfoPage2/CardLeft.jsx
+++ b/src/components/MainPage/CompanyInfoPage/CompanyInfoPage2/CardLeft.jsx
@@ -55,6 +55,13 @@ export default function CardLeft() {
               formatter: (val) => `${val}%`,
             },
           },
+          dataLabels: {
+            enabled: true,
+            style: {
+              fontWeight: '200', // 글자 두께 (300은 얇은 두께)
+              colors: ['#FFFFFF'], // 글자 색상
+            },
+          },
           plotOptions: {
             pie: {
               donut: {
@@ -95,7 +102,6 @@ export default function CardLeft() {
         <div className="flex items-center space-x-2">
           <span className="text-gray-900 font-semibold">매출비중 추이</span>
         </div>
-        <span className="text-gray-500 text-sm">단위 : %</span>
       </div>
 
       <div className="h-[280px] w-full mb-6">
@@ -104,7 +110,7 @@ export default function CardLeft() {
           className="mr-2 float-right bottom-2 right-2 text-xs font-medium text-gray-700"
           style={{ pointerEvents: 'none' }}
         >
-          기준: 2023
+          단위: %, 기준: 2023
         </div>
       </div>
 

--- a/src/components/MainPage/CompanyInfoPage/CompanyInfoPage2/CardRight.jsx
+++ b/src/components/MainPage/CompanyInfoPage/CompanyInfoPage2/CardRight.jsx
@@ -3,14 +3,21 @@ import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import { CompanyContext } from '../../../../contexts/CompanyContext';
 
-export default function CardRight() {
+export default function CardRight({ onNoData }) {
   const [marketShareData, setMarketShareData] = useState([]);
   const { userInputCompany } = useContext(CompanyContext);
 
   useEffect(() => {
-    fetch(`http://localhost:8080/api/companyInfo/${userInputCompany}/marketShare`)
+    fetch(`/api/companyInfo/${userInputCompany}/marketShare`)
       .then((response) => response.json())
-      .then((data) => setMarketShareData(data))
+      .then((data) => {
+        setMarketShareData(data);
+        if (data.length === 0) {
+          onNoData(true);
+        } else {
+          onNoData(false);
+        }
+      })
       .catch((error) => console.error('Error fetching data: ', error));
   }, []);
 
@@ -73,7 +80,6 @@ export default function CardRight() {
         <div className="flex items-center space-x-2">
           <span className="text-gray-900 font-semibold">시장 점유율</span>
         </div>
-        <span className="text-gray-500 text-sm">단위 : %</span>
       </div>
 
       <div className="absolute bottom-0 h-[375px] w-full">

--- a/src/components/MainPage/CompanyInfoPage/CompanyInfoPage2/CompanyInfoPage2.jsx
+++ b/src/components/MainPage/CompanyInfoPage/CompanyInfoPage2/CompanyInfoPage2.jsx
@@ -1,14 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import CardLeft from './CardLeft';
 import CardRight from './CardRight';
 
 export default function CompanyInfoPage2() {
+  const [isRightCardEmpty, setIsRightCardEmpty] = useState(false);
+
   return (
-    <div className="grid gap-7 md:grid-cols-2 h-full">
-      {/* Left Chart */}
+    <div
+      className={`grid gap-7 ${isRightCardEmpty ? 'grid-cols-1 justify-center items-center h-full' : 'md:grid-cols-2'}`}
+    >
       <CardLeft />
-      {/* Right Chart */}
-      <CardRight />
+
+      {!isRightCardEmpty && <CardRight onNoData={(isEmpty) => setIsRightCardEmpty(isEmpty)} />}
     </div>
   );
 }

--- a/src/components/MainPage/CompanyInfoPage/CompanyInfoPage3/CompanyInfoPage3.jsx
+++ b/src/components/MainPage/CompanyInfoPage/CompanyInfoPage3/CompanyInfoPage3.jsx
@@ -122,8 +122,8 @@ export default function CompanyInfoPage3() {
 
   return (
     <div>
-      <div className="mt-2 font-black flex justify-between items-center border-b pb-2">
-        <span className="text-sm text-muted-foreground ml-auto">기준: 2023.12</span>
+      <div className="mt-2 font-black flex justify-between items-center pb-2">
+        <span className="text-sm font-medium ml-auto">기준: 2023.12</span>
       </div>
       <Nav
         fill

--- a/src/index.css
+++ b/src/index.css
@@ -73,6 +73,7 @@ body{
     color: black; 
     border: none; 
     padding: 0.5rem 1rem;
+    font-weight: 550;
 }
   
 .custom-tabs .nav-link.active-tab {
@@ -82,7 +83,7 @@ body{
 
 .custom-tabs .nav-link:hover {
     text-decoration: none; 
-    color: #0056b3;
+    color: gray;
 }
 
   


### PR DESCRIPTION
## 개요

- 시장 점유율 데이터 없는 경우 매출 비중 추이만 나오도록 수정

## 작업사항

- #114 

## 변경로직

- useState 활용해서 기업정보 페이지2에서 카드 컴포넌트로 props 전달하여 구현
