### PR TITLE
차트 Log 수정

### DIFF
--- a/src/components/MainPage/AnalyzeChartPage/CompanySummaryInfo.jsx
+++ b/src/components/MainPage/AnalyzeChartPage/CompanySummaryInfo.jsx
@@ -63,9 +63,7 @@ export default function CompanySummaryInfo({ isBarClick, durationType, date }) {
         </div>
         <div className="flex flex-row justify-between">
           <p className="m-0 text-sm">거래량</p>
-          <p className="m-0 text-sm">
-            {renderedData.volume != null ? `${renderedData.volume.toLocaleString()}원` : '-'}
-          </p>
+          <p className="m-0 text-sm">{renderedData.volume != null ? `${renderedData.volume.toLocaleString()}` : '-'}</p>
         </div>
       </div>
     </div>

--- a/src/components/MainPage/AnalyzeChartPage/PastInfos.jsx
+++ b/src/components/MainPage/AnalyzeChartPage/PastInfos.jsx
@@ -85,7 +85,7 @@ export default function PastInfos({ isBarClick, date }) {
             {
               press: '한국경제TV',
               title: "   기대치 밑돈 실적에 삼성전자 목표주가 '줄하향'   ",
-              desc: '  주가 탄력성이 예상보다 강할 수 있다"고 밝혔다. 김동원 KB증권 리서치센터장도 "P/…진입 여부가 중장기 상승 모멘텀으로 작용할 것"이라고 내다봤다. (사진=연합뉴스...  ',
+              desc: '주가 탄력성이 예상보다 강할 수 있다"고 밝혔다. 김동원 KB증권 리서치센터장도 "P/…진입 여부가 중장기 상승 모멘텀으로 작용할 것"이라고 내다봤다. (사진=연합뉴스...  ',
               date: ' 2024.11.01 ',
               url: 'http://v.daum.net/v/20241101094350956',
             },
@@ -168,7 +168,7 @@ export default function PastInfos({ isBarClick, date }) {
         };
         try {
           const res = await axios.get(url, { params });
-          console.log(res);
+
           const data = res.data;
           const result = data.map((item) => ({
             logo: securitiesData[item.writer],
@@ -215,7 +215,7 @@ export default function PastInfos({ isBarClick, date }) {
               >
                 {article.title}
               </a>
-              <p className="text-xs p-0 m-0">{article.desc}</p>
+              <p className="text-xs p-0 m-0 line-clamp-2">{article.desc}</p>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## 개요

- 차트 Log 수정
- 
## 작업사항

- #128 

## 변경로직

- 거래량 옆 '원' 삭제
- tailwind css 'line-clamp-2' 활용해서 뉴스 기사 제목 아래 요약 데이터 2줄만 렌더링
